### PR TITLE
Enable Lua scripting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module liberdade.bsb.br/baas/api
 
 go 1.19
 
-require github.com/lib/pq v1.10.7 // indirect
+require (
+	github.com/lib/pq v1.10.7
+	github.com/yuin/gopher-lua v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/yuin/gopher-lua v1.0.0 h1:pQCf0LN67Kf7M5u7vRd40A8M1I8IMLrxlqngUJgZ0Ow=
+github.com/yuin/gopher-lua v1.0.0/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@ default: run
 
 test:
 	go test ./database
+	go test ./services/*.go
 
 build: test
 	go build -o main.exe main/main.go

--- a/services/luavm.go
+++ b/services/luavm.go
@@ -1,0 +1,12 @@
+package services
+
+import (
+    "github.com/yuin/gopher-lua"
+)
+
+func RunLua(script string) error {
+    L := lua.NewState()
+    defer L.Close()
+    return L.DoString(script)
+}
+

--- a/services/luavm_test.go
+++ b/services/luavm_test.go
@@ -1,0 +1,13 @@
+package services
+
+import (
+    "testing"
+)
+
+func TestLuaVm(t *testing.T) {
+    script := `print("hello from Lua")`
+    if err := RunLua(script); err != nil {
+        t.Errorf("Couldnt run lua: %#v\n", err)
+    }
+}
+


### PR DESCRIPTION
Closes #34 

Since mruby in Go is not completely up to date, this PR suggests using [Lua](https://github.com/yuin/gopher-lua) as an alternative.