### PR TITLE
Refactor admin listing endpoints

### DIFF
--- a/src/br/bsb/liberdade/baas/business.clj
+++ b/src/br/bsb/liberdade/baas/business.clj
@@ -486,9 +486,22 @@
             result (db/run-operation operation {})]
         (assoc state things result))))
 
+(def unwanted-fields [:password])
+(defn- maybe-cleanup-fields [things]
+  (if (nil? things)
+    nil
+    (map #(reduce (fn [state [k v]]
+                    (if (utils/in? unwanted-fields k)
+		      state
+                      (assoc state k (str v))))
+                  {}
+  	          %)
+         things)))
+
 (defn- format-list-all-things-output-xf [state]
   {"error"         (get state :error nil)
-   (:things state) (get state (:things state) nil)})
+   (:things state) (-> (get state (:things state) nil)
+                       maybe-cleanup-fields)})
 
 (defn- list-all-things [client-auth-key things]
   (->> {:error nil


### PR DESCRIPTION
Closes #98 

This PR:
- Coerces timestamps into strings before returning them
- Remove some unwanted fields from the admin responses